### PR TITLE
Added !default to the $spinner-color variable in SASS so it can be overridden with a different color.

### DIFF
--- a/sass/spinner/spinner.scss
+++ b/sass/spinner/spinner.scss
@@ -1,6 +1,6 @@
 @import "base";
 
-$spinner-color: rgba(#003, 0.3);
+$spinner-color: rgba(#003, 0.3) !default;
 
 @include keyframes(spinner) {
   0%   { @include rotateZ(0deg); }
@@ -19,7 +19,7 @@ $spinner-color: rgba(#003, 0.3);
     $spinner-color -1.5em 0 0 0,
     $spinner-color -1.1em -1.1em 0 0,
     $spinner-color 0 -1.5em 0 0,
-    $spinner-color 1.1em -1.1em 0 0  
+    $spinner-color 1.1em -1.1em 0 0
   );
   display: inline-block;
   font-size: 10px;


### PR DESCRIPTION
Using !default against a variable in SASS means it will not be overwritten if it's already been defined.
This means the colour can be overridden in projects using the library.

This should probably be done for all color variables in the library.
Might I suggest you could extract this into a different sass file such as '_config.scss'.
If you would like help doing this I'd be happy to provide further pull requests.

Once you've accepted the pull request could you also push this to bower so I can install it.

Thanks,

Darren 
